### PR TITLE
Constructor doc update, declaring type of $key

### DIFF
--- a/src/Fernet.php
+++ b/src/Fernet.php
@@ -50,7 +50,7 @@ class Fernet {
     /**
      * Creates an instance of the Fernet encoder/decoder
      *
-     * @param $key the Fernet key, encoded in base64url format
+     * @param string $key the Fernet key, encoded in base64url format
      */
     public function __construct($key) {
         if (!function_exists('openssl_random_pseudo_bytes') && !function_exists('mcrypt_create_iv')) {


### PR DESCRIPTION
I've added the parameter type, so IDE's can pick up the correct parameter type when constructing `Fernet`.