### PR TITLE
Remove support for PHP 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sublime*
+composer.lock
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 dist: trusty
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
 
 notification:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: php
 dist: trusty
+
+before_install:
+    - travis_retry composer self-update
+
+install:
+    - travis_retry composer install --prefer-source --no-interaction --dev
+
+script:
+    - composer test
+
 php:
     - 7.0
     - 7.1
     - 7.2
     - 7.3
     - 7.4
+
+cache:
+    directories:
+        - $HOME/.composer/cache
 
 notification:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - travis_retry composer self-update
 
 install:
-    - travis_retry composer install --prefer-source --no-interaction --dev
+    - travis_retry composer install --prefer-source --no-interaction
 
 script:
     - composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Remove PHP5 compatibility
+
 ## Version 0.5.0
 
 - Fixes timing attack vulnerability (#1)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "kelvinmo/fernet-php",
     "description": "An implementation of the Fernet token specification in PHP.",
     "require": {
-        "php": ">=5.4",
+        "php": "^7.0",
         "ext-hash": "*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-openssl": "This package requires either the mcrypt or openssl extension."
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^6.0"
     },
     "license": "BSD-3-Clause",
     "authors": [
@@ -21,5 +21,11 @@
     ],
     "autoload": {
         "classmap": [ "src/" ]
+    },
+    "scripts": {
+        "test": [
+            "@composer install",
+            "phpunit"
+        ]
     }
 }

--- a/src/Fernet.php
+++ b/src/Fernet.php
@@ -123,6 +123,7 @@ class Fernet {
         } elseif (function_exists('mcrypt_decrypt')) {
             $message = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $this->encryption_key, $ciphertext, 'cbc', $iv);
         }
+        if ($message === false) return null;
 
         $pad = ord($message[strlen($message) - 1]);
         if (substr_count(substr($message, -$pad), chr($pad)) != $pad) return null;

--- a/tests/FernetTest.php
+++ b/tests/FernetTest.php
@@ -2,6 +2,8 @@
 
 namespace Fernet;
 
+use PHPUnit\Framework\TestCase;
+
 class FernetMock extends Fernet {
     private $time;
 
@@ -28,7 +30,7 @@ class FernetGenerateMock extends FernetMock {
     }
 }
 
-class FernetTest extends \PHPUnit_Framework_TestCase {
+class FernetTest extends TestCase {
 
     public function __construct() {
         parent::__construct();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,10 +21,4 @@ spl_autoload_register(function ($class) {
     return;
 });
 
-// PHPUnit 6 introduced a breaking change that
-// removed PHPUnit_Framework_TestCase as a base class,
-// and replaced it with \PHPUnit\Framework\TestCase
-if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-
 ?>


### PR DESCRIPTION
This removes official support for PHP 5.x.  The code should still work with PHP 5, but unit tests no longer work due to version dependency on PHPUnit.